### PR TITLE
Fixed uncaught promise rejection on JSON.parse

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -26,10 +26,14 @@ class Client{
       }catch(err){
         return reject(err.message);
       }
-      const json = JSON.parse(res.text);
-      if(json.error) return reject(json.error);
 
-      resolve(new Account(json));
+      try {
+          const json = JSON.parse(res.text);
+          resolve(new Account(json));
+      } catch (err) {
+          reject(err)
+      }
+
     });
   }
 


### PR DESCRIPTION
When the API returns a HTML file instead of JSON the code will return a uncaught promise.
Fixed by wrapping the JSON parse into try / catch.